### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This server is an interface that uses the [Model Context Protocol (MCP)](https:/
 
 With this MCP server, Claude AI can perform operations such as searching, creating, and updating esa documents.
 
+<a href="https://glama.ai/mcp/servers/@kajirita2002/esa-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kajirita2002/esa-mcp-server/badge" alt="esa Server MCP server" />
+</a>
+
 ## About the Repository
 
 This repository provides a standalone implementation of the esa MCP server. It integrates Claude AI with esa to streamline document management.


### PR DESCRIPTION
This PR adds a badge for the [esa MCP Server](https://glama.ai/mcp/servers/@kajirita2002/esa-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kajirita2002/esa-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kajirita2002/esa-mcp-server/badge" alt="esa Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.