### PR TITLE
fix: remove esa_delete_post functionality

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -87,11 +87,6 @@ npm start
      - `created_by` (string, optional): 投稿者のscreen_name (チームオーナーのみ指定可能)
      - `original_revision` (string, optional): 更新の基準となるリビジョン
 
-5. `esa_delete_post`
-   - 記事を削除します
-   - 入力:
-     - `post_number` (number, required): 削除する記事番号
-
 ### コメント関連
 
 1. `esa_list_comments`

--- a/README.md
+++ b/README.md
@@ -107,11 +107,6 @@ This MCP server provides the following tools:
      - `created_by` (string, optional): Poster's screen_name (only team owners can specify)
      - `original_revision` (string, optional): Revision to base the update on
 
-5. `esa_delete_post`
-   - Delete a post
-   - Input:
-     - `post_number` (number, required): Post number to delete
-
 ### Comment Related
 
 1. `esa_list_comments`

--- a/index.ts
+++ b/index.ts
@@ -46,10 +46,6 @@ interface UpdatePostArgs {
   original_revision?: string;
 }
 
-interface DeletePostArgs {
-  post_number: number;
-}
-
 interface ListCommentsArgs {
   post_number: number;
   page?: number;
@@ -227,21 +223,6 @@ const updatePostTool: Tool = {
   },
 };
 
-const deletePostTool: Tool = {
-  name: "esa_delete_post",
-  description: "Delete a post",
-  inputSchema: {
-    type: "object",
-    properties: {
-      post_number: {
-        type: "number",
-        description: "Post number to delete",
-      },
-    },
-    required: ["post_number"],
-  },
-};
-
 const listCommentsTool: Tool = {
   name: "esa_list_comments",
   description: "Get a list of comments for a post",
@@ -405,16 +386,6 @@ class EsaClient {
     return response.json();
   }
 
-  async deletePost(post_number: number): Promise<any> {
-    const url = `${this.baseUrl}/posts/${post_number}`;
-    const response = await fetch(url, {
-      method: "DELETE",
-      headers: this.headers,
-    });
-
-    return response.status === 204 ? { success: true } : response.json();
-  }
-
   async listComments(post_number: number, page?: number, per_page?: number): Promise<any> {
     const params = new URLSearchParams();
     
@@ -551,17 +522,6 @@ async function main() {
             };
           }
 
-          case "esa_delete_post": {
-            const args = request.params.arguments as unknown as DeletePostArgs;
-            if (!args.post_number) {
-              throw new Error("post_number is required");
-            }
-            const response = await esaClient.deletePost(args.post_number);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
           case "esa_list_comments": {
             const args = request.params.arguments as unknown as ListCommentsArgs;
             if (!args.post_number) {
@@ -649,7 +609,6 @@ async function main() {
         getPostTool,
         createPostTool,
         updatePostTool,
-        deletePostTool,
         listCommentsTool,
         getCommentTool,
         createCommentTool,


### PR DESCRIPTION
## Changes Made
- Complete removal of the esa_delete_post functionality
  - Removed DeletePostArgs interface
  - Removed deletePostTool definition
  - Removed deletePost method from EsaClient class
  - Removed esa_delete_post case handling
  - Removed deletePostTool from the tools array
  - Removed related descriptions from README.md and README.ja.md

## Reason for Changes
- To simplify the application's functionality
- The delete feature was not being utilized, and removal reduces security risks

## Impact Scope
- Only affects the post deletion functionality
- No impact on other features (retrieving, creating, updating posts, and comment-related functions)

## Testing Details
- Server startup testing
- Verified that remaining functionalities work properly