### PR TITLE
feat: add automatic signature to created posts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,6 +6,10 @@
 
 このMCPサーバーによって、Claude AIはesaのドキュメントの検索、作成、更新などの操作を行えるようになります。
 
+### 特別な機能
+
+- **自動署名**: 作成されるすべての投稿に自動的に「by esa-mcp-server」という署名を追加します
+
 ## リポジトリについて
 
 このリポジトリは、esa MCPサーバーの独立した実装を提供します。Claude AIとesaを統合し、ドキュメント管理を効率化します。
@@ -21,8 +25,11 @@
 ### インストール
 
 ```bash
-# 必要なパッケージをインストール
-npm install
+# グローバルにインストール
+npm install -g @kajirita2002/esa-mcp-server-auto-signature
+
+# または直接npxで使用
+npx @kajirita2002/esa-mcp-server-auto-signature
 ```
 
 ### 環境変数の設定
@@ -31,6 +38,21 @@ npm install
 # 環境変数の設定
 export ESA_ACCESS_TOKEN="your_esa_access_token"
 export ESA_TEAM="your_team_name"
+```
+
+### MCP設定例
+
+このMCPサーバーを使用する場合は、`mcp_config.json`ファイルに以下の設定を追加してください：
+
+```json
+"esa": {
+  "command": "npx",
+  "args": ["-y", "@kajirita2002/esa-mcp-server-auto-signature"],
+  "env": {
+    "ESA_ACCESS_TOKEN": "your_esa_access_token",
+    "ESA_TEAM": "your_team_name"
+  }
+}
 ```
 
 ### サーバーの起動
@@ -63,7 +85,7 @@ npm start
      - `include` (string, optional): レスポンスに含める関連データ (例: 'comments,stargazers')
 
 3. `esa_create_post`
-   - 新しい記事を作成します
+   - 新しい記事を作成します（自動的に「by esa-mcp-server」という署名が追加されます）
    - 入力:
      - `name` (string, required): 記事のタイトル
      - `body_md` (string, optional): 記事の本文 (Markdown形式)
@@ -135,7 +157,7 @@ npm start
 {
   "number": 123,
   "name": "プロジェクトXの進捗報告",
-  "body_md": "# 今週の進捗\n\n- 機能Aの実装完了\n- 機能Bのテスト開始\n\n## 次週の予定\n\n- 機能Cの実装開始",
+  "body_md": "# 今週の進捗\n\n- 機能Aの実装完了\n- 機能Bのテスト開始\n\n## 次週の予定\n\n- 機能Cの実装開始\n\n---\nby esa-mcp-server",
   "wip": false,
   "created_at": "2023-06-01T12:34:56+09:00",
   "updated_at": "2023-06-01T12:34:56+09:00",

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This server is an interface that uses the [Model Context Protocol (MCP)](https:/
 
 With this MCP server, Claude AI can perform operations such as searching, creating, and updating esa documents.
 
+### Special Features
+
+- **Auto-signature**: Automatically appends "by esa-mcp-server" signature to all created posts
+
 ## About the Repository
 
 This repository provides a standalone implementation of the esa MCP server. It integrates Claude AI with esa to streamline document management.
@@ -24,10 +28,10 @@ This repository provides a standalone implementation of the esa MCP server. It i
 
 ```bash
 # Install globally
-npm install -g @kajirita2002/esa-mcp-server
+npm install -g @kajirita2002/esa-mcp-server-auto-signature
 
 # Or use directly with npx
-npx @kajirita2002/esa-mcp-server
+npx @kajirita2002/esa-mcp-server-auto-signature
 ```
 
 ### Setting Environment Variables
@@ -45,7 +49,7 @@ If you're using this MCP server, add the following configuration to your `mcp_co
 ```json
 "esa": {
   "command": "npx",
-  "args": ["-y", "@kajirita2002/esa-mcp-server"],
+  "args": ["-y", "@kajirita2002/esa-mcp-server-auto-signature"],
   "env": {
     "ESA_ACCESS_TOKEN": "your_esa_access_token",
     "ESA_TEAM": "your_team_name"
@@ -83,7 +87,7 @@ This MCP server provides the following tools:
      - `include` (string, optional): Related data to include in the response (e.g. 'comments,stargazers')
 
 3. `esa_create_post`
-   - Create a new post
+   - Create a new post (automatically adds "by esa-mcp-server" signature)
    - Input:
      - `name` (string, required): Post title
      - `body_md` (string, optional): Post body (Markdown format)
@@ -155,7 +159,7 @@ Here's an example of Claude using this MCP server to create an esa post:
 {
   "number": 123,
   "name": "Project X Progress Report",
-  "body_md": "# This Week's Progress\n\n- Implementation of Feature A completed\n- Testing of Feature B started\n\n## Next Week's Plan\n\n- Start implementation of Feature C",
+  "body_md": "# This Week's Progress\n\n- Implementation of Feature A completed\n- Testing of Feature B started\n\n## Next Week's Plan\n\n- Start implementation of Feature C\n\n---\nby esa-mcp-server",
   "wip": false,
   "created_at": "2023-06-01T12:34:56+09:00",
   "updated_at": "2023-06-01T12:34:56+09:00",

--- a/index.ts
+++ b/index.ts
@@ -366,6 +366,14 @@ class EsaClient {
 
   async createPost(postData: Omit<CreatePostArgs, 'template_post_id'> & { template_post_id?: number }): Promise<any> {
     const url = `${this.baseUrl}/posts`;
+    
+    // 本文に自動署名を追加
+    if (postData.body_md) {
+      postData.body_md = `${postData.body_md}\n\n---\nby esa-mcp-server`;
+    } else {
+      postData.body_md = "by esa-mcp-server";
+    }
+    
     const response = await fetch(url, {
       method: "POST",
       headers: this.headers,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@kajirita2002/esa-mcp-server",
-  "version": "1.1.0",
+  "name": "@kajirita2002/esa-mcp-server-auto-signature",
+  "version": "1.2.0",
   "description": "MCP server for interacting with esa API",
   "license": "MIT",
   "author": "kajirita2002",


### PR DESCRIPTION
## Changes Made
- Modified `createPost` method in `index.ts` to automatically append "by esa-mcp-server" signature to all created posts
- Changed package name to `@kajirita2002/esa-mcp-server-auto-signature`
- Updated version to 1.2.0 (minor version bump for new feature)
- Updated both English and Japanese documentation (README.md and README.ja.md) to reflect new functionality

## Reason for Changes
- Added ability to automatically identify posts created through the MCP server by adding a consistent signature
- Makes it easy to track which content was created programmatically

## Key Configurations/Specifications
- Signature format: "by esa-mcp-server"
- Added after a horizontal rule (---) at the end of post content
- If no body content is provided, only the signature is set

## Impact Scope
- Affects only the post creation functionality
- All created posts will now include the signature
- No impact on other functionalities (post updates, comments, etc.)

## Testing Details
- Built successfully with `npm run build`
- Verified code logic ensures signature is added properly in all cases